### PR TITLE
Renaming of Deprecated Thrift gen name 

### DIFF
--- a/api.thrift
+++ b/api.thrift
@@ -1,6 +1,6 @@
 include 'general.thrift'
 
-namespace csharp NodeApi
+namespace netstd NodeApi
 namespace netcore NodeApi
 namespace java com.credits.client.node.thrift.generated
 namespace cpp api

--- a/apidiag.thrift
+++ b/apidiag.thrift
@@ -1,6 +1,6 @@
 include 'general.thrift'
 
-namespace csharp NodeApiDiag
+namespace netstd NodeApiDiag
 namespace netcore NodeApiDiag
 namespace java com.credits.client.node.diag.thrift.generated
 namespace cpp api_diag

--- a/apiexec.thrift
+++ b/apiexec.thrift
@@ -2,7 +2,7 @@ include 'general.thrift'
 include 'api.thrift'
 namespace java com.credits.client.executor.thrift.generated.apiexec
 namespace cpp apiexec
-namespace csharp NodeApiExec
+namespace netstd NodeApiExec
 namespace netcore NodeApiExec
 
 struct GetSeedResult

--- a/general.thrift
+++ b/general.thrift
@@ -1,6 +1,6 @@
 namespace java com.credits.general.thrift.generated
 namespace cpp general
-namespace csharp NodeApi
+namespace netstd NodeApi
 namespace netcore NodeApi
 
 typedef i64 AccessID


### PR DESCRIPTION
Thrift Deprecated generator rename from Csharp to netstd as advised by thrift. 